### PR TITLE
feat: Memory UI — browse and delete Qdrant patterns (v2)

### DIFF
--- a/src/api/memory_api.py
+++ b/src/api/memory_api.py
@@ -5,8 +5,12 @@ Exposes Qdrant-backed memory store for inspection and management via Web UI.
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/memory", tags=["memory"])
 
@@ -35,43 +39,14 @@ def _unavailable() -> JSONResponse:
 @router.get("/projects")
 async def list_projects() -> JSONResponse:
     """Return distinct project_ids that have patterns stored in Qdrant."""
-    if _memory_store is None or not await _memory_store.is_available():
+    store = _memory_store  # snapshot — защита от гонки
+    if store is None or not await store.is_available():
         return _unavailable()
-
     try:
-        _, qm = _try_import_qdrant()
-        if qm is None:
-            return _unavailable()
-
-        client = await _memory_store._get_client()
-        if client is None:
-            return _unavailable()
-
-        await _memory_store._ensure_collection()
-
-        # Scroll through all points collecting project_ids
-        project_ids: set[str] = set()
-        offset = None
-        while True:
-            results, next_offset = await client.scroll(
-                collection_name=_memory_store._collection,
-                limit=100,
-                offset=offset,
-                with_payload=["project_id"],
-                with_vectors=False,
-            )
-            for point in results:
-                pid = (point.payload or {}).get("project_id")
-                if pid:
-                    project_ids.add(str(pid))
-            if next_offset is None:
-                break
-            offset = next_offset
-
-        return JSONResponse(sorted(project_ids))
+        projects = await store.list_projects()
+        return JSONResponse(projects)
     except Exception as exc:
-        import logging
-        logging.getLogger(__name__).debug("list_projects error: %s", exc)
+        logger.debug("list_projects error: %s", exc)
         return _unavailable()
 
 
@@ -82,110 +57,28 @@ async def list_patterns(
     limit: int = 50,
 ) -> JSONResponse:
     """List memory patterns from Qdrant, with optional filters."""
-    if _memory_store is None or not await _memory_store.is_available():
+    store = _memory_store  # snapshot — защита от гонки
+    if store is None or not await store.is_available():
         return _unavailable()
-
     try:
-        _, qm = _try_import_qdrant()
-        if qm is None:
-            return _unavailable()
-
-        client = await _memory_store._get_client()
-        if client is None:
-            return _unavailable()
-
-        await _memory_store._ensure_collection()
-
-        # Build filter conditions
-        conditions = []
-        if project_id:
-            conditions.append(
-                qm.FieldCondition(
-                    key="project_id",
-                    match=qm.MatchValue(value=project_id),
-                )
-            )
-        if category:
-            conditions.append(
-                qm.FieldCondition(
-                    key="category",
-                    match=qm.MatchValue(value=category),
-                )
-            )
-
-        scroll_filter = qm.Filter(must=conditions) if conditions else None
-
-        results, _ = await client.scroll(
-            collection_name=_memory_store._collection,
-            limit=min(limit, 500),
-            with_payload=True,
-            with_vectors=False,
-            scroll_filter=scroll_filter,
-        )
-
-        items = []
-        for point in results:
-            payload = dict(point.payload or {})
-            items.append(
-                {
-                    "id": str(point.id),
-                    "project_id": payload.pop("project_id", ""),
-                    "category": payload.pop("category", ""),
-                    "content": payload.pop("content", ""),
-                    "metadata": payload,
-                    "score": None,
-                }
-            )
-
+        items = await store.list_patterns(project_id, category, limit)
         return JSONResponse({"items": items, "total": len(items)})
     except Exception as exc:
-        import logging
-        logging.getLogger(__name__).debug("list_patterns error: %s", exc)
+        logger.debug("list_patterns error: %s", exc)
         return _unavailable()
 
 
 @router.delete("/{point_id}")
 async def delete_pattern(point_id: str) -> JSONResponse:
     """Delete a memory pattern by its Qdrant point id."""
-    if _memory_store is None or not await _memory_store.is_available():
+    store = _memory_store  # snapshot — защита от гонки
+    if store is None or not await store.is_available():
         return _unavailable()
-
     try:
-        _, qm = _try_import_qdrant()
-        if qm is None:
-            return _unavailable()
-
-        client = await _memory_store._get_client()
-        if client is None:
-            return _unavailable()
-
-        await _memory_store._ensure_collection()
-
-        # Check that the point exists first
-        points = await client.retrieve(
-            collection_name=_memory_store._collection,
-            ids=[point_id],
-            with_payload=False,
-            with_vectors=False,
-        )
-        if not points:
+        found = await store.delete_pattern(point_id)
+        if not found:
             return JSONResponse({"error": "not found"}, status_code=404)
-
-        await client.delete(
-            collection_name=_memory_store._collection,
-            points_selector=qm.PointIdsList(points=[point_id]),
-        )
         return JSONResponse({"status": "deleted"})
     except Exception as exc:
-        import logging
-        logging.getLogger(__name__).debug("delete_pattern error: %s", exc)
+        logger.debug("delete_pattern error: %s", exc)
         return _unavailable()
-
-
-def _try_import_qdrant():  # type: ignore[return]
-    try:
-        from qdrant_client import AsyncQdrantClient  # type: ignore[import-not-found]
-        from qdrant_client.http import models as qm  # type: ignore[import-not-found]
-        return AsyncQdrantClient, qm
-    except ImportError:
-        return None, None

--- a/src/api/memory_api.py
+++ b/src/api/memory_api.py
@@ -1,0 +1,191 @@
+"""Memory API — /api/v1/memory
+
+Exposes Qdrant-backed memory store for inspection and management via Web UI.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+router = APIRouter(prefix="/api/v1/memory", tags=["memory"])
+
+_memory_store = None
+
+
+def set_memory_store(store) -> None:  # type: ignore[no-untyped-def]
+    global _memory_store
+    _memory_store = store
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unavailable() -> JSONResponse:
+    return JSONResponse({"error": "memory not available"}, status_code=503)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/projects")
+async def list_projects() -> JSONResponse:
+    """Return distinct project_ids that have patterns stored in Qdrant."""
+    if _memory_store is None or not await _memory_store.is_available():
+        return _unavailable()
+
+    try:
+        _, qm = _try_import_qdrant()
+        if qm is None:
+            return _unavailable()
+
+        client = await _memory_store._get_client()
+        if client is None:
+            return _unavailable()
+
+        await _memory_store._ensure_collection()
+
+        # Scroll through all points collecting project_ids
+        project_ids: set[str] = set()
+        offset = None
+        while True:
+            results, next_offset = await client.scroll(
+                collection_name=_memory_store._collection,
+                limit=100,
+                offset=offset,
+                with_payload=["project_id"],
+                with_vectors=False,
+            )
+            for point in results:
+                pid = (point.payload or {}).get("project_id")
+                if pid:
+                    project_ids.add(str(pid))
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        return JSONResponse(sorted(project_ids))
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).debug("list_projects error: %s", exc)
+        return _unavailable()
+
+
+@router.get("")
+async def list_patterns(
+    project_id: str = "",
+    category: str = "",
+    limit: int = 50,
+) -> JSONResponse:
+    """List memory patterns from Qdrant, with optional filters."""
+    if _memory_store is None or not await _memory_store.is_available():
+        return _unavailable()
+
+    try:
+        _, qm = _try_import_qdrant()
+        if qm is None:
+            return _unavailable()
+
+        client = await _memory_store._get_client()
+        if client is None:
+            return _unavailable()
+
+        await _memory_store._ensure_collection()
+
+        # Build filter conditions
+        conditions = []
+        if project_id:
+            conditions.append(
+                qm.FieldCondition(
+                    key="project_id",
+                    match=qm.MatchValue(value=project_id),
+                )
+            )
+        if category:
+            conditions.append(
+                qm.FieldCondition(
+                    key="category",
+                    match=qm.MatchValue(value=category),
+                )
+            )
+
+        scroll_filter = qm.Filter(must=conditions) if conditions else None
+
+        results, _ = await client.scroll(
+            collection_name=_memory_store._collection,
+            limit=min(limit, 500),
+            with_payload=True,
+            with_vectors=False,
+            scroll_filter=scroll_filter,
+        )
+
+        items = []
+        for point in results:
+            payload = dict(point.payload or {})
+            items.append(
+                {
+                    "id": str(point.id),
+                    "project_id": payload.pop("project_id", ""),
+                    "category": payload.pop("category", ""),
+                    "content": payload.pop("content", ""),
+                    "metadata": payload,
+                    "score": None,
+                }
+            )
+
+        return JSONResponse({"items": items, "total": len(items)})
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).debug("list_patterns error: %s", exc)
+        return _unavailable()
+
+
+@router.delete("/{point_id}")
+async def delete_pattern(point_id: str) -> JSONResponse:
+    """Delete a memory pattern by its Qdrant point id."""
+    if _memory_store is None or not await _memory_store.is_available():
+        return _unavailable()
+
+    try:
+        _, qm = _try_import_qdrant()
+        if qm is None:
+            return _unavailable()
+
+        client = await _memory_store._get_client()
+        if client is None:
+            return _unavailable()
+
+        await _memory_store._ensure_collection()
+
+        # Check that the point exists first
+        points = await client.retrieve(
+            collection_name=_memory_store._collection,
+            ids=[point_id],
+            with_payload=False,
+            with_vectors=False,
+        )
+        if not points:
+            return JSONResponse({"error": "not found"}, status_code=404)
+
+        await client.delete(
+            collection_name=_memory_store._collection,
+            points_selector=qm.PointIdsList(points=[point_id]),
+        )
+        return JSONResponse({"status": "deleted"})
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).debug("delete_pattern error: %s", exc)
+        return _unavailable()
+
+
+def _try_import_qdrant():  # type: ignore[return]
+    try:
+        from qdrant_client import AsyncQdrantClient  # type: ignore[import-not-found]
+        from qdrant_client.http import models as qm  # type: ignore[import-not-found]
+        return AsyncQdrantClient, qm
+    except ImportError:
+        return None, None

--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,8 @@ from .api.notifications_api import router as notifications_router
 from .api.providers import router as providers_router
 from .api.queue_api import router as queue_router
 from .api.queue_api import set_queue_manager
+from .api.memory_api import router as memory_router
+from .api.memory_api import set_memory_store as memory_api_set_store
 from .api.reviews import router as reviews_router
 from .api.reviews import set_database as reviews_set_db
 from .api.reviews import set_queue_manager as reviews_set_queue
@@ -98,6 +100,7 @@ def create_app() -> FastAPI:
             url=cfg.memory.qdrant_url, collection=cfg.memory.collection
         )
         set_memory_store(memory_store)
+        memory_api_set_store(memory_store)
         reviews_set_db(db)
         reviews_set_queue(queue)
         health_set_db(db)
@@ -145,6 +148,7 @@ def create_app() -> FastAPI:
     app.include_router(queue_router)
     app.include_router(logs_router)
     app.include_router(reviews_router)
+    app.include_router(memory_router)
 
     if cfg.ui.enabled:
         mount_ui(app)

--- a/src/memory_store.py
+++ b/src/memory_store.py
@@ -236,6 +236,137 @@ class MemoryStore:
             return []
 
     # ------------------------------------------------------------------
+    # Public query/management API
+    # ------------------------------------------------------------------
+
+    async def list_projects(self) -> list[str]:
+        """Return sorted list of distinct project_ids. Caps at 10_000 points."""
+        try:
+            client = await self._get_client()
+            if client is None:
+                return []
+            await self._ensure_collection()
+            project_ids: set[str] = set()
+            offset = None
+            max_iterations = 100
+            truncated = False
+            for _ in range(max_iterations):
+                results, next_offset = await client.scroll(
+                    collection_name=self._collection,
+                    limit=100,
+                    offset=offset,
+                    with_payload=["project_id"],
+                    with_vectors=False,
+                )
+                for point in results:
+                    pid = (point.payload or {}).get("project_id")
+                    if pid:
+                        project_ids.add(str(pid))
+                if next_offset is None:
+                    break
+                offset = next_offset
+            else:
+                truncated = True
+            if truncated:
+                logger.warning(
+                    "list_projects: truncated after %d iterations (10K points cap)",
+                    max_iterations,
+                )
+            return sorted(project_ids)
+        except Exception as exc:
+            logger.debug("list_projects failed (non-fatal): %s", exc)
+            return []
+
+    async def list_patterns(
+        self,
+        project_id: str = "",
+        category: str = "",
+        limit: int = 50,
+    ) -> list[dict]:
+        """Return patterns with optional filter. Limit capped at 500."""
+        try:
+            client = await self._get_client()
+            if client is None:
+                return []
+            await self._ensure_collection()
+
+            _, qm = _try_import_qdrant()
+            if qm is None:
+                return []
+
+            conditions = []
+            if project_id:
+                conditions.append(
+                    qm.FieldCondition(
+                        key="project_id",
+                        match=qm.MatchValue(value=project_id),
+                    )
+                )
+            if category:
+                conditions.append(
+                    qm.FieldCondition(
+                        key="category",
+                        match=qm.MatchValue(value=category),
+                    )
+                )
+            scroll_filter = qm.Filter(must=conditions) if conditions else None
+
+            results, _ = await client.scroll(
+                collection_name=self._collection,
+                limit=min(limit, 500),
+                with_payload=True,
+                with_vectors=False,
+                scroll_filter=scroll_filter,
+            )
+
+            items = []
+            for point in results:
+                payload = dict(point.payload or {})
+                items.append(
+                    {
+                        "id": str(point.id),
+                        "project_id": payload.pop("project_id", ""),
+                        "category": payload.pop("category", ""),
+                        "content": payload.pop("content", ""),
+                        "metadata": payload,
+                    }
+                )
+            return items
+        except Exception as exc:
+            logger.debug("list_patterns failed (non-fatal): %s", exc)
+            return []
+
+    async def delete_pattern(self, point_id: str) -> bool:
+        """Delete pattern by point_id. Returns False if not found."""
+        try:
+            client = await self._get_client()
+            if client is None:
+                return False
+            await self._ensure_collection()
+
+            _, qm = _try_import_qdrant()
+            if qm is None:
+                return False
+
+            points = await client.retrieve(
+                collection_name=self._collection,
+                ids=[point_id],
+                with_payload=False,
+                with_vectors=False,
+            )
+            if not points:
+                return False
+
+            await client.delete(
+                collection_name=self._collection,
+                points_selector=qm.PointIdsList(points=[point_id]),
+            )
+            return True
+        except Exception as exc:
+            logger.debug("delete_pattern failed (non-fatal): %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 

--- a/src/ui/static/index.html
+++ b/src/ui/static/index.html
@@ -1391,6 +1391,69 @@
     </div>
   </div>
 
+  <!-- ───────────────── MEMORY ───────────────── -->
+  <div x-show="activeTab === 'memory'" x-init="$watch('activeTab', v => v==='memory' && loadMemoryProjects())">
+    <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px; margin-bottom:16px;">
+      <div class="section-title" style="margin-bottom:0;">🧠 Memory Patterns</div>
+      <div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
+        <select class="inp" style="width:180px;" x-model="memoryFilter.project_id" @change="loadMemoryPatterns()">
+          <option value="">All projects</option>
+          <template x-for="pid in memoryProjects" :key="pid">
+            <option :value="pid" x-text="pid"></option>
+          </template>
+        </select>
+        <select class="inp" style="width:160px;" x-model="memoryFilter.category" @change="loadMemoryPatterns()">
+          <option value="">All categories</option>
+          <option value="error_pattern">error_pattern</option>
+          <option value="review_history">review_history</option>
+        </select>
+        <button class="btn btn-ghost btn-sm" @click="loadMemoryProjects(); loadMemoryPatterns()">↻ Refresh</button>
+      </div>
+    </div>
+
+    <!-- Unavailable banner -->
+    <div x-show="memoryUnavailable" class="card" style="text-align:center; padding:32px; color:var(--text-3);">
+      <div style="font-size:2rem; margin-bottom:10px;">🔌</div>
+      <div style="font-size:.95rem; color:var(--yellow);">Memory store unavailable</div>
+      <div style="font-size:.82rem; margin-top:6px;">Qdrant is not reachable or memory is disabled.</div>
+    </div>
+
+    <!-- Table -->
+    <div x-show="!memoryUnavailable" class="card" style="padding:0; overflow:hidden;">
+      <table class="tbl">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Content</th>
+            <th>File</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="m in memoryPatterns" :key="m.id">
+            <tr>
+              <td>
+                <span class="badge"
+                  :class="m.category==='error_pattern' ? 'badge-red' : 'badge-blue'"
+                  x-text="m.category"></span>
+              </td>
+              <td style="font-size:.82rem; max-width:420px; word-break:break-word;"
+                x-text="m.content?.substring(0,100) + (m.content?.length > 100 ? '…' : '')"></td>
+              <td class="mono" style="font-size:.75rem; color:var(--text-3);" x-text="m.metadata?.file_path || '—'"></td>
+              <td>
+                <button class="btn btn-ghost btn-sm" style="color:var(--red);"
+                  @click="deleteMemoryPattern(m.id)">Delete</button>
+              </td>
+            </tr>
+          </template>
+          <tr x-show="memoryPatterns.length === 0 && !memoryUnavailable">
+            <td colspan="4" style="text-align:center; color:var(--text-3); padding:36px; font-size:.84rem;">No patterns stored</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   <!-- ───────────────── LOGS ───────────────── -->
   <div x-show="activeTab === 'logs'">
     <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:14px; flex-wrap:wrap; gap:8px;">
@@ -1499,6 +1562,7 @@ function app() {
       { id: 'targets',       label: '🎯 Targets' },
       { id: 'reviews',       label: '📋 Reviews' },
       { id: 'logs',          label: '📜 Logs' },
+      { id: 'memory',        label: '🧠 Memory' },
     ],
 
     config: {
@@ -1557,6 +1621,11 @@ function app() {
     reviewPage: 0,
     reviewPageSize: 20,
     selectedReview: null,
+
+    memoryPatterns: [],
+    memoryProjects: [],
+    memoryFilter: { project_id: '', category: '' },
+    memoryUnavailable: false,
 
     logLines: [],
     logFilter: '',
@@ -1812,6 +1881,38 @@ function app() {
 
     async loadDashboardRecent() {
       try { const r = await fetch('/api/v1/reviews/recent?limit=8'); this.dashboardRecent = await r.json(); } catch (_) {}
+    },
+
+    async loadMemoryProjects() {
+      try {
+        const r = await fetch('/api/v1/memory/projects');
+        if (r.status === 503) { this.memoryUnavailable = true; return; }
+        this.memoryUnavailable = false;
+        this.memoryProjects = await r.json();
+        await this.loadMemoryPatterns();
+      } catch (e) { this.memoryUnavailable = true; }
+    },
+
+    async loadMemoryPatterns() {
+      try {
+        const params = new URLSearchParams({ limit: 100 });
+        if (this.memoryFilter.project_id) params.set('project_id', this.memoryFilter.project_id);
+        if (this.memoryFilter.category) params.set('category', this.memoryFilter.category);
+        const r = await fetch(`/api/v1/memory?${params}`);
+        if (r.status === 503) { this.memoryUnavailable = true; return; }
+        this.memoryUnavailable = false;
+        const data = await r.json();
+        this.memoryPatterns = data.items || [];
+      } catch (e) { this.memoryUnavailable = true; }
+    },
+
+    async deleteMemoryPattern(id) {
+      if (!confirm('Delete this memory pattern?')) return;
+      try {
+        const r = await fetch(`/api/v1/memory/${id}`, { method: 'DELETE' });
+        if (r.ok) { this.showToast('Pattern deleted'); await this.loadMemoryPatterns(); }
+        else { const d = await r.json(); this.showToast(d.error || 'Delete failed', 'error'); }
+      } catch (e) { this.showToast('Network error: ' + e, 'error'); }
     },
 
     async loadReviews() {

--- a/tests/test_api/test_memory_api.py
+++ b/tests/test_api/test_memory_api.py
@@ -1,0 +1,209 @@
+"""Tests for /api/v1/memory — list patterns, delete, list projects."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock qdrant objects
+# ---------------------------------------------------------------------------
+
+
+def _make_point(point_id: str, payload: dict):
+    """Create a mock Qdrant ScoredPoint / Record object."""
+    p = MagicMock()
+    p.id = point_id
+    p.payload = payload
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Fixture: minimal app wired with memory router
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def memory_app():
+    """FastAPI app with only the memory router included."""
+    from fastapi import FastAPI
+
+    from src.api.memory_api import router as memory_router
+    from src.api.memory_api import set_memory_store
+
+    application = FastAPI()
+    application.include_router(memory_router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=application), base_url="http://test"
+    ) as client:
+        yield client, set_memory_store
+
+    # Reset singleton after test
+    set_memory_store(None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListPatterns:
+    async def test_list_patterns_returns_results(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = True
+        store._collection = "reviewer_memory"
+
+        mock_client = AsyncMock()
+        store._get_client.return_value = mock_client
+        store._ensure_collection = AsyncMock()
+
+        point = _make_point(
+            "uuid-1",
+            {
+                "project_id": "p1",
+                "category": "error_pattern",
+                "content": "SQL injection in query.py",
+                "file_path": "query.py",
+            },
+        )
+        mock_client.scroll.return_value = ([point], None)
+
+        set_store(store)
+
+        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
+            qm = MagicMock()
+            mock_qdrant.return_value = (MagicMock(), qm)
+            r = await client.get("/api/v1/memory?project_id=p1")
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 1
+        item = data["items"][0]
+        assert item["id"] == "uuid-1"
+        assert item["project_id"] == "p1"
+        assert item["category"] == "error_pattern"
+        assert "SQL injection" in item["content"]
+        assert item["metadata"]["file_path"] == "query.py"
+
+    async def test_list_patterns_unavailable(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = False
+        set_store(store)
+
+        r = await client.get("/api/v1/memory?project_id=p1")
+        assert r.status_code == 503
+        assert r.json()["error"] == "memory not available"
+
+    async def test_list_patterns_no_store(self, memory_app):
+        client, set_store = memory_app
+        set_store(None)
+
+        r = await client.get("/api/v1/memory?project_id=p1")
+        assert r.status_code == 503
+
+
+class TestDeletePattern:
+    async def test_delete_pattern_success(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = True
+        store._collection = "reviewer_memory"
+
+        mock_client = AsyncMock()
+        store._get_client.return_value = mock_client
+        store._ensure_collection = AsyncMock()
+
+        point = _make_point("uuid-del", {"project_id": "p1", "category": "error_pattern", "content": "x"})
+        mock_client.retrieve.return_value = [point]
+        mock_client.delete = AsyncMock()
+
+        set_store(store)
+
+        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
+            qm = MagicMock()
+            mock_qdrant.return_value = (MagicMock(), qm)
+            r = await client.delete("/api/v1/memory/uuid-del")
+
+        assert r.status_code == 200
+        assert r.json()["status"] == "deleted"
+        mock_client.delete.assert_called_once()
+
+    async def test_delete_pattern_not_found(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = True
+        store._collection = "reviewer_memory"
+
+        mock_client = AsyncMock()
+        store._get_client.return_value = mock_client
+        store._ensure_collection = AsyncMock()
+        mock_client.retrieve.return_value = []  # not found
+
+        set_store(store)
+
+        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
+            qm = MagicMock()
+            mock_qdrant.return_value = (MagicMock(), qm)
+            r = await client.delete("/api/v1/memory/no-such-id")
+
+        assert r.status_code == 404
+
+    async def test_delete_unavailable(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = False
+        set_store(store)
+
+        r = await client.delete("/api/v1/memory/some-id")
+        assert r.status_code == 503
+
+
+class TestListProjects:
+    async def test_list_projects(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = True
+        store._collection = "reviewer_memory"
+
+        mock_client = AsyncMock()
+        store._get_client.return_value = mock_client
+        store._ensure_collection = AsyncMock()
+
+        p1 = _make_point("id-1", {"project_id": "proj-alpha"})
+        p2 = _make_point("id-2", {"project_id": "proj-beta"})
+        p3 = _make_point("id-3", {"project_id": "proj-alpha"})  # duplicate
+        mock_client.scroll.return_value = ([p1, p2, p3], None)
+
+        set_store(store)
+
+        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
+            qm = MagicMock()
+            mock_qdrant.return_value = (MagicMock(), qm)
+            r = await client.get("/api/v1/memory/projects")
+
+        assert r.status_code == 200
+        projects = r.json()
+        assert sorted(projects) == ["proj-alpha", "proj-beta"]
+
+    async def test_list_projects_unavailable(self, memory_app):
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = False
+        set_store(store)
+
+        r = await client.get("/api/v1/memory/projects")
+        assert r.status_code == 503

--- a/tests/test_api/test_memory_api.py
+++ b/tests/test_api/test_memory_api.py
@@ -2,25 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
-import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-
-
-# ---------------------------------------------------------------------------
-# Helpers — mock qdrant objects
-# ---------------------------------------------------------------------------
-
-
-def _make_point(point_id: str, payload: dict):
-    """Create a mock Qdrant ScoredPoint / Record object."""
-    p = MagicMock()
-    p.id = point_id
-    p.payload = payload
-    return p
-
 
 # ---------------------------------------------------------------------------
 # Fixture: minimal app wired with memory router
@@ -58,29 +43,18 @@ class TestListPatterns:
 
         store = AsyncMock()
         store.is_available.return_value = True
-        store._collection = "reviewer_memory"
-
-        mock_client = AsyncMock()
-        store._get_client.return_value = mock_client
-        store._ensure_collection = AsyncMock()
-
-        point = _make_point(
-            "uuid-1",
+        store.list_patterns.return_value = [
             {
+                "id": "uuid-1",
                 "project_id": "p1",
                 "category": "error_pattern",
                 "content": "SQL injection in query.py",
-                "file_path": "query.py",
-            },
-        )
-        mock_client.scroll.return_value = ([point], None)
-
+                "metadata": {"file_path": "query.py"},
+            }
+        ]
         set_store(store)
 
-        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
-            qm = MagicMock()
-            mock_qdrant.return_value = (MagicMock(), qm)
-            r = await client.get("/api/v1/memory?project_id=p1")
+        r = await client.get("/api/v1/memory?project_id=p1")
 
         assert r.status_code == 200
         data = r.json()
@@ -91,6 +65,7 @@ class TestListPatterns:
         assert item["category"] == "error_pattern"
         assert "SQL injection" in item["content"]
         assert item["metadata"]["file_path"] == "query.py"
+        store.list_patterns.assert_awaited_once_with("p1", "", 50)
 
     async def test_list_patterns_unavailable(self, memory_app):
         client, set_store = memory_app
@@ -110,6 +85,36 @@ class TestListPatterns:
         r = await client.get("/api/v1/memory?project_id=p1")
         assert r.status_code == 503
 
+    async def test_list_patterns_filters_by_category(self, memory_app):
+        """Verify category parameter is forwarded to store.list_patterns."""
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = True
+        store.list_patterns.return_value = []
+        set_store(store)
+
+        r = await client.get("/api/v1/memory?project_id=p1&category=error_pattern")
+
+        assert r.status_code == 200
+        # Verify both project_id and category were passed through correctly
+        store.list_patterns.assert_awaited_once_with("p1", "error_pattern", 50)
+
+    async def test_list_patterns_limit_cap(self, memory_app):
+        """Verify limit is passed to store; capping happens inside MemoryStore."""
+        client, set_store = memory_app
+
+        store = AsyncMock()
+        store.is_available.return_value = True
+        store.list_patterns.return_value = []
+        set_store(store)
+
+        r = await client.get("/api/v1/memory?limit=1000")
+
+        assert r.status_code == 200
+        # API passes limit as-is; MemoryStore enforces the 500 cap internally
+        store.list_patterns.assert_awaited_once_with("", "", 1000)
+
 
 class TestDeletePattern:
     async def test_delete_pattern_success(self, memory_app):
@@ -117,45 +122,24 @@ class TestDeletePattern:
 
         store = AsyncMock()
         store.is_available.return_value = True
-        store._collection = "reviewer_memory"
-
-        mock_client = AsyncMock()
-        store._get_client.return_value = mock_client
-        store._ensure_collection = AsyncMock()
-
-        point = _make_point("uuid-del", {"project_id": "p1", "category": "error_pattern", "content": "x"})
-        mock_client.retrieve.return_value = [point]
-        mock_client.delete = AsyncMock()
-
+        store.delete_pattern.return_value = True
         set_store(store)
 
-        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
-            qm = MagicMock()
-            mock_qdrant.return_value = (MagicMock(), qm)
-            r = await client.delete("/api/v1/memory/uuid-del")
+        r = await client.delete("/api/v1/memory/uuid-del")
 
         assert r.status_code == 200
         assert r.json()["status"] == "deleted"
-        mock_client.delete.assert_called_once()
+        store.delete_pattern.assert_awaited_once_with("uuid-del")
 
     async def test_delete_pattern_not_found(self, memory_app):
         client, set_store = memory_app
 
         store = AsyncMock()
         store.is_available.return_value = True
-        store._collection = "reviewer_memory"
-
-        mock_client = AsyncMock()
-        store._get_client.return_value = mock_client
-        store._ensure_collection = AsyncMock()
-        mock_client.retrieve.return_value = []  # not found
-
+        store.delete_pattern.return_value = False
         set_store(store)
 
-        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
-            qm = MagicMock()
-            mock_qdrant.return_value = (MagicMock(), qm)
-            r = await client.delete("/api/v1/memory/no-such-id")
+        r = await client.delete("/api/v1/memory/no-such-id")
 
         assert r.status_code == 404
 
@@ -176,27 +160,15 @@ class TestListProjects:
 
         store = AsyncMock()
         store.is_available.return_value = True
-        store._collection = "reviewer_memory"
-
-        mock_client = AsyncMock()
-        store._get_client.return_value = mock_client
-        store._ensure_collection = AsyncMock()
-
-        p1 = _make_point("id-1", {"project_id": "proj-alpha"})
-        p2 = _make_point("id-2", {"project_id": "proj-beta"})
-        p3 = _make_point("id-3", {"project_id": "proj-alpha"})  # duplicate
-        mock_client.scroll.return_value = ([p1, p2, p3], None)
-
+        store.list_projects.return_value = ["proj-alpha", "proj-beta"]
         set_store(store)
 
-        with patch("src.api.memory_api._try_import_qdrant") as mock_qdrant:
-            qm = MagicMock()
-            mock_qdrant.return_value = (MagicMock(), qm)
-            r = await client.get("/api/v1/memory/projects")
+        r = await client.get("/api/v1/memory/projects")
 
         assert r.status_code == 200
         projects = r.json()
         assert sorted(projects) == ["proj-alpha", "proj-beta"]
+        store.list_projects.assert_awaited_once()
 
     async def test_list_projects_unavailable(self, memory_app):
         client, set_store = memory_app


### PR DESCRIPTION
## Summary

Adds a **🧠 Memory** tab to the Web UI for inspecting and managing stored review patterns in Qdrant.

## Changes

### New: `src/api/memory_api.py`
Three REST endpoints for the Memory UI:
- `GET /api/v1/memory/projects` — distinct project IDs from Qdrant (cap: 10K points)
- `GET /api/v1/memory?project_id=&category=&limit=` — filtered pattern list (limit capped at 500)
- `DELETE /api/v1/memory/{point_id}` — delete pattern by ID (404 if not found, 503 if unavailable)

### Updated: `src/memory_store.py`
Three new public methods encapsulating all Qdrant access:
- `list_projects()` — scroll with 10K cap + truncation warning
- `list_patterns(project_id, category, limit)` — filtered scroll, `min(limit, 500)`
- `delete_pattern(point_id)` — retrieve→check→delete, returns bool

### Updated: `src/main.py`
- Router registered, `memory_api_set_store()` called in lifespan

### Updated: `src/ui/static/index.html`
- New **🧠 Memory** tab with project selector, category filter, patterns table, Delete buttons (with confirm dialog)

### New: `tests/test_api/test_memory_api.py`
10 tests covering all AC paths (list, filter by category/project, limit passthrough, delete success/404/503, projects list/503).

## Review rounds
- Round 1: 6 BLOCKING found and fixed (encapsulation, duplication, unbounded scroll, race condition, 2 missing tests)
- Round 2: 0 BLOCKING — Architect ✅ Architect ✅ Python Dev ✅ QA ✅ Security ✅

## Tests
```
582 passed
```