### PR TITLE
feat: Q-2 GET /reviews/{id}/diff + Q-9 clickable MR URL in review comment

### DIFF
--- a/src/api/reviews.py
+++ b/src/api/reviews.py
@@ -140,6 +140,27 @@ async def export_csv():  # type: ignore[no-untyped-def]
     )
 
 
+@router.get("/{review_id}/diff")
+async def get_review_diff(review_id: int) -> JSONResponse:
+    """Return diff metadata for a review: diff_hash, branches, prompt_names."""
+    if _db is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+    rec = await _db.get_review(review_id)
+    if rec is None:
+        raise HTTPException(status_code=404, detail="Review not found")
+    return JSONResponse(
+        {
+            "review_id": rec.id,
+            "diff_hash": rec.diff_hash,
+            "mr_iid": rec.mr_iid,
+            "project_id": rec.project_id,
+            "source_branch": rec.source_branch,
+            "target_branch": rec.target_branch,
+            "prompt_names": rec.prompt_names,
+        }
+    )
+
+
 @router.get("/{review_id}")
 async def get_review(review_id: int) -> JSONResponse:
     if _db is None:

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -51,7 +51,8 @@ def _safe_mr_url(url: str) -> str:
 
 def _safe_mr_title(title: str) -> str:
     """Escape markdown chars that could break the link text."""
-    return title.replace("\\", "\\\\").replace("]", "\\]")
+    title = title or ""
+    return title.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 
 @runtime_checkable

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -911,6 +911,12 @@ class Reviewer:
         summary_text = "\n\n".join(header_parts) + "\n\n---\n\n" + summary_text
 
         summary_comment = _format_summary_comment(summary_text, inline_count=len(inline_comments))
+        # Q-9: prepend clickable MR link header if mr_url is available
+        if record.mr_url:
+            mr_header = (
+                f"🔍 [MR #{record.mr_iid}: {record.mr_title}]({record.mr_url})\n\n"
+            )
+            summary_comment = mr_header + summary_comment
         await gitlab.post_mr_note(job.project_id, job.mr_iid, summary_comment)
         record.status = "posted"
         logger.info("Review posted: project=%s MR!%d", job.project_id, job.mr_iid)

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -23,6 +23,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol, runtime_checkable
+from urllib.parse import urlparse
 
 from . import metrics as _metrics
 from .config import AppConfig, ReviewTarget, get_config
@@ -35,6 +36,22 @@ from .notifier import notify as _dispatch_notify
 from .pipeline import PipelineManager, RoleResult, ReviewRole
 from .prompt_engine import PromptEngine
 from .queue_manager import ReviewJob
+
+
+def _safe_mr_url(url: str) -> str:
+    """Return url only if scheme is http/https, else empty string."""
+    try:
+        scheme = urlparse(url).scheme
+        if scheme not in ("http", "https"):
+            return ""
+    except Exception:
+        return ""
+    return url
+
+
+def _safe_mr_title(title: str) -> str:
+    """Escape markdown chars that could break the link text."""
+    return title.replace("\\", "\\\\").replace("]", "\\]")
 
 
 @runtime_checkable
@@ -913,10 +930,11 @@ class Reviewer:
         summary_comment = _format_summary_comment(summary_text, inline_count=len(inline_comments))
         # Q-9: prepend clickable MR link header if mr_url is available
         if record.mr_url:
-            mr_header = (
-                f"🔍 [MR #{record.mr_iid}: {record.mr_title}]({record.mr_url})\n\n"
-            )
-            summary_comment = mr_header + summary_comment
+            safe_url = _safe_mr_url(record.mr_url)
+            safe_title = _safe_mr_title(record.mr_title)
+            if safe_url:
+                mr_header = f"🔍 [MR #{record.mr_iid}: {safe_title}]({safe_url})\n\n"
+                summary_comment = mr_header + summary_comment
         await gitlab.post_mr_note(job.project_id, job.mr_iid, summary_comment)
         record.status = "posted"
         logger.info("Review posted: project=%s MR!%d", job.project_id, job.mr_iid)

--- a/tests/test_api/test_reviews_api.py
+++ b/tests/test_api/test_reviews_api.py
@@ -193,3 +193,41 @@ class TestCSVExport:
         r = await app.get("/api/v1/reviews/export.csv")
         assert "99" in r.text
         assert "42" in r.text
+
+
+class TestGetReviewDiff:
+    async def test_diff_returns_expected_fields(self, app, db):
+        rec = await _seed(
+            db,
+            project_id="mygroup/myrepo",
+            mr_iid=7,
+            source_branch="feat/cool",
+            target_branch="main",
+            diff_hash="abc123def456",
+            prompt_names=["system", "lang_python"],
+        )
+        r = await app.get(f"/api/v1/reviews/{rec.id}/diff")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["review_id"] == rec.id
+        assert data["diff_hash"] == "abc123def456"
+        assert data["mr_iid"] == 7
+        assert data["project_id"] == "mygroup/myrepo"
+        assert data["source_branch"] == "feat/cool"
+        assert data["target_branch"] == "main"
+        assert data["prompt_names"] == ["system", "lang_python"]
+
+    async def test_diff_404_for_nonexistent_review(self, app):
+        r = await app.get("/api/v1/reviews/99999/diff")
+        assert r.status_code == 404
+
+    async def test_diff_503_when_db_unavailable(self, app):
+        from src.api import reviews as reviews_mod
+
+        original_db = reviews_mod._db
+        try:
+            reviews_mod._db = None
+            r = await app.get("/api/v1/reviews/1/diff")
+            assert r.status_code == 503
+        finally:
+            reviews_mod._db = original_db

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1004,3 +1004,42 @@ def test_make_llm_client_uses_config_timeout():
     assert kwargs.get("timeout") == 42, (
         f"Expected LLMClient(timeout=42), got timeout={kwargs.get('timeout')!r}"
     )
+
+
+class TestSummaryCommentMrUrl:
+    """Q-9: MR URL link prepended to summary comment when mr_url is set."""
+
+    async def test_summary_contains_mr_link_when_url_set(
+        self, reviewer, mock_gitlab, mock_llm, db, cfg_with_target, mock_mr
+    ):
+        """When mr_url is non-empty the summary comment starts with a clickable MR link."""
+        mock_mr.web_url = "http://gitlab.example.com/mr/7"
+        set_database(db)
+        with (
+            patch("src.reviewer._make_gitlab_client", return_value=mock_gitlab),
+            patch("src.reviewer._make_llm_client", return_value=mock_llm),
+            patch("src.reviewer.get_config", return_value=cfg_with_target),
+        ):
+            await reviewer.review_job(ReviewJob(project_id=42, mr_iid=7))
+
+        mock_gitlab.post_mr_note.assert_called_once()
+        comment = mock_gitlab.post_mr_note.call_args[0][2]
+        assert "[MR #7" in comment, f"Expected MR link in comment, got:\n{comment[:300]}"
+        assert "http://gitlab.example.com/mr/7" in comment
+
+    async def test_summary_no_mr_link_when_url_empty(
+        self, reviewer, mock_gitlab, mock_llm, db, cfg_with_target, mock_mr
+    ):
+        """When mr_url is empty the summary comment must NOT contain a MR markdown link."""
+        mock_mr.web_url = ""
+        set_database(db)
+        with (
+            patch("src.reviewer._make_gitlab_client", return_value=mock_gitlab),
+            patch("src.reviewer._make_llm_client", return_value=mock_llm),
+            patch("src.reviewer.get_config", return_value=cfg_with_target),
+        ):
+            await reviewer.review_job(ReviewJob(project_id=42, mr_iid=7))
+
+        mock_gitlab.post_mr_note.assert_called_once()
+        comment = mock_gitlab.post_mr_note.call_args[0][2]
+        assert "[MR #7" not in comment, f"Did not expect MR link when url is empty:\n{comment[:300]}"

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1074,5 +1074,6 @@ class TestSummaryCommentMrUrl:
         ):
             await reviewer.review_job(ReviewJob(project_id=42, mr_iid=7))
         comment = mock_gitlab.post_mr_note.call_args[0][2]
-        assert "\\]" in comment or "Fix" in comment  # title escaped and present
+        assert "\\]" in comment, f"Expected escaped bracket '\\]' in comment, got:\n{comment[:300]}"
+        assert "Fix" in comment, f"Expected title text 'Fix' in comment, got:\n{comment[:300]}"
         assert "http://gitlab.example.com/mr/7" in comment

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1043,3 +1043,36 @@ class TestSummaryCommentMrUrl:
         mock_gitlab.post_mr_note.assert_called_once()
         comment = mock_gitlab.post_mr_note.call_args[0][2]
         assert "[MR #7" not in comment, f"Did not expect MR link when url is empty:\n{comment[:300]}"
+
+    async def test_summary_no_mr_link_when_url_has_javascript_scheme(
+        self, reviewer, mock_gitlab, mock_llm, db, cfg_with_target, mock_mr
+    ):
+        """javascript: URL must NOT produce a link in summary comment."""
+        mock_mr.web_url = "javascript:alert(1)"
+        set_database(db)
+        with (
+            patch("src.reviewer._make_gitlab_client", return_value=mock_gitlab),
+            patch("src.reviewer._make_llm_client", return_value=mock_llm),
+            patch("src.reviewer.get_config", return_value=cfg_with_target),
+        ):
+            await reviewer.review_job(ReviewJob(project_id=42, mr_iid=7))
+        comment = mock_gitlab.post_mr_note.call_args[0][2]
+        assert "javascript:" not in comment
+        assert "[MR #7" not in comment
+
+    async def test_summary_mr_title_with_brackets_escaped(
+        self, reviewer, mock_gitlab, mock_llm, db, cfg_with_target, mock_mr
+    ):
+        """MR title with ] chars must be escaped in link text."""
+        mock_mr.web_url = "http://gitlab.example.com/mr/7"
+        mock_mr.title = "Fix [bug] in auth"
+        set_database(db)
+        with (
+            patch("src.reviewer._make_gitlab_client", return_value=mock_gitlab),
+            patch("src.reviewer._make_llm_client", return_value=mock_llm),
+            patch("src.reviewer.get_config", return_value=cfg_with_target),
+        ):
+            await reviewer.review_job(ReviewJob(project_id=42, mr_iid=7))
+        comment = mock_gitlab.post_mr_note.call_args[0][2]
+        assert "\\]" in comment or "Fix" in comment  # title escaped and present
+        assert "http://gitlab.example.com/mr/7" in comment


### PR DESCRIPTION
## Summary

Two quick improvements from the backlog:

### Q-9: Clickable MR URL in review comment
Prepends a clickable link to the GitLab MR at the top of every summary review comment:
```
🔍 [MR #7: Fix auth bug](https://gitlab.example.com/project/-/merge_requests/7)
```
- `_safe_mr_url()`: validates URL scheme (http/https allowlist — blocks `javascript:`, `data:`, `ftp://`, etc.)
- `_safe_mr_title()`: escapes `\`, `[`, `]` to prevent markdown link injection
- `title or ""` for None-safety
- Skips header gracefully if `mr_url` is empty or has invalid scheme

### Q-2: GET /api/v1/reviews/{id}/diff
New endpoint returning diff metadata for a review:
```json
{"review_id": 42, "diff_hash": "abc123", "mr_iid": 7, "project_id": "group/repo", "source_branch": "feat/x", "target_branch": "main", "prompt_names": ["system", "lang_python"]}
```
Returns 404 if review not found, 503 if DB unavailable.

## Review rounds
- Round 1: 1 BLOCKING fixed (Security HIGH: mr_url scheme validation), MEDIUM fixed (mr_title markdown escape)
- Round 2: 1 BLOCKING fixed (QA: OR-logic in test made it vacuous), MINOR fixed ([ escaping + None-safety)
- Round 3: 0 BLOCKING — Security CLEAR ✅ · Architect APPROVE ✅ · Python Dev APPROVE ✅ · QA PASS ✅

## Tests
```
589 passed (+7 new)
```