### PR TITLE
chore: fix 52 ruff lint errors, improve test assertions (#11, #8, #10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,10 @@ After v0.2: open `http://server:8000/ui/` to configure everything.
 - **_mask_provider uses mode="json"**: `p.model_dump(mode="json")` returns `"**********"` for SecretStr, then `_mask_provider` replaces it with `"****"`. Changing to `model_dump()` (no mode) would return a `SecretStr` object — not JSON-serializable.
 - **Per-role LLMClient cache**: `_role_llm_cache` in `PipelineManager` holds `LLMClient` instances per role. `PipelineManager` is one-shot (one review = one instance). If api_key rotates, the cached client is stale — recreate `PipelineManager`.
 - **RoleModelConfig key**: keys in `roles` dict must match `ReviewRole.value` strings exactly (e.g. `"architect"`, `"developer"`, `"tester"`, `"security"`, `"reviewer"`). Wrong key = silently uses global LLM.
+- **StrEnum vs str+Enum**: `ReviewRole` and `MemoryCategory` use `StrEnum` (Python 3.11+). Do NOT revert to `class X(str, Enum)` — ruff UP042 flags it and StrEnum is cleaner.
+- **E402 in pipeline.py**: module-level imports must appear before any code (including regex compiles). Move `_SLOTS_RE` after all imports, not before.
+- **S108 in tests**: never use hardcoded `/tmp/...` paths in test data — use `tmp_path` pytest fixture or `tempfile.mkdtemp()`. Ruff flags it as S108.
+- **test_pipeline_v2_true_enables_new_pipeline**: uses `tmp_path` fixture (injected by pytest) to get a real temp dir for `prompts_dir`. Signature must include `tmp_path` parameter.
 
 ## Status
 
@@ -309,3 +313,4 @@ After v0.2: open `http://server:8000/ui/` to configure everything.
 | api_key: SecretStr (no field_serializer), model_dump(mode="json") in API | v0.15 | ✅ Done |
 | URL validator for provider.url (http/https only) | v0.15 | ✅ Done |
 | timeout: int = 300 in ModelConfig (configurable) | v0.15 | ✅ Done |
+| chore: ruff lint fix — 52 errors fixed (#11, #8, #10) | chore | ✅ Done |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -338,5 +338,8 @@ async def _with_retry(fn):
 | 🟡 P2 | Q-6: Weekly stats API | S | Analytics | ✅ Done (`8969dd7`) |
 | 🟢 P3 | FT-5: Reviewer Feedback Learning | XL | Long-term | 🔲 Open |
 | 🟢 P3 | FT-6: Automation Rules (YAML) | XL | Power users | 🔲 Open |
+| 🟢 P3 | #11: ruff lint fix (52 errors) | XS | Code quality | ✅ Done (`chore/ruff-lint-fix`) |
+| 🟢 P3 | #8: Q-9 test assertions (MR link at start) | XS | Test quality | ✅ Done |
+| 🟢 P3 | #10: `_safe_mr_title` type annotation `str\|None` | XS | Type safety | ✅ Done |
 
 **Открытые CODE_REVIEW items:** WARN-4, WARN-6, WARN-7, STYLE-1 (все Low/Medium)

--- a/src/api/providers.py
+++ b/src/api/providers.py
@@ -12,7 +12,7 @@ from ..llm_client import ModelInfo, get_model_info, list_models
 router = APIRouter(prefix="/api/v1/providers", tags=["providers"])
 
 
-def _mask_provider(p: "Provider") -> dict:
+def _mask_provider(p: Provider) -> dict:
     # mode="json" serializes SecretStr as "**********" (string), Enum → str, etc.
     d = p.model_dump(mode="json")
     if d.get("api_key"):
@@ -98,7 +98,8 @@ async def get_models(provider_id: str) -> JSONResponse:
     if not provider:
         raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not found")
 
-    models: list[ModelInfo] = await list_models(provider.url, provider.type.value, provider.api_key.get_secret_value())
+    api_key = provider.api_key.get_secret_value()
+    models: list[ModelInfo] = await list_models(provider.url, provider.type.value, api_key)
     return JSONResponse([{"id": m.id, "context_length": m.context_length} for m in models])
 
 
@@ -110,7 +111,8 @@ async def get_model_info_endpoint(provider_id: str, model_name: str) -> JSONResp
     if not provider:
         raise HTTPException(status_code=404, detail=f"Provider '{provider_id}' not found")
 
-    info = await get_model_info(provider.url, model_name, provider.type.value, provider.api_key.get_secret_value())
+    api_key = provider.api_key.get_secret_value()
+    info = await get_model_info(provider.url, model_name, provider.type.value, api_key)
     return JSONResponse(
         {
             "id": info.id,

--- a/src/config.py
+++ b/src/config.py
@@ -242,7 +242,8 @@ class AppConfig(BaseModel):
         llm_key = os.getenv("GLR_LLM_API_KEY", "")
         if llm_key:
             for p in self.providers:
-                if not p.api_key.get_secret_value() and (p.id == self.model.provider_id or not self.model.provider_id):
+                is_active = p.id == self.model.provider_id or not self.model.provider_id
+                if not p.api_key.get_secret_value() and is_active:
                     p.api_key = SecretStr(llm_key)
                     break
         return self

--- a/src/context_builder.py
+++ b/src/context_builder.py
@@ -288,7 +288,11 @@ async def get_task_context(
             # Fall through to MR description fallback
 
     # Fallback: use MR title + description
-    logger.debug("No linked issue found for project=%s MR!%d — using MR description", project_id, mr_iid)
+    logger.debug(
+        "No linked issue found for project=%s MR!%d — using MR description",
+        project_id,
+        mr_iid,
+    )
     return f"## Task: MR !{mr_iid} — {mr_title}\n\n{mr_description}"
 
 
@@ -359,7 +363,8 @@ async def get_dynamic_context(
             if not _TEST_PATTERNS.search(candidate_name):
                 continue
             # Match test files related to the changed file
-            if base_name.lower() not in candidate_name.lower() and not candidate_name.lower().startswith("test_"):
+            name_lower = candidate_name.lower()
+            if base_name.lower() not in name_lower and not name_lower.startswith("test_"):
                 continue
             test_path = tree_item["path"]
             if test_path == file_path:

--- a/src/main.py
+++ b/src/main.py
@@ -27,13 +27,13 @@ from .api.health import set_database as health_set_db
 from .api.health import set_queue_manager as health_set_queue
 from .api.logs_api import router as logs_router
 from .api.logs_api import set_log_buffer
+from .api.memory_api import router as memory_router
+from .api.memory_api import set_memory_store as memory_api_set_store
 from .api.metrics_api import router as metrics_router
 from .api.notifications_api import router as notifications_router
 from .api.providers import router as providers_router
 from .api.queue_api import router as queue_router
 from .api.queue_api import set_queue_manager
-from .api.memory_api import router as memory_router
-from .api.memory_api import set_memory_store as memory_api_set_store
 from .api.reviews import router as reviews_router
 from .api.reviews import set_database as reviews_set_db
 from .api.reviews import set_queue_manager as reviews_set_queue
@@ -42,11 +42,10 @@ from .backends import create_queue_manager
 from .config import CONFIG_PATH, reload_config
 from .db import Database
 from .log_buffer import setup_log_buffer
-from .prompt_engine import PromptEngine
 from .memory_store import MemoryStore
-from .reviewer import Reviewer
+from .prompt_engine import PromptEngine
+from .reviewer import Reviewer, set_memory_store
 from .reviewer import set_database as reviewer_set_db
-from .reviewer import set_memory_store
 from .ui.router import mount_ui
 from .webhook import make_webhook_router
 from .webhook import set_queue_manager as webhook_set_queue

--- a/src/memory_store.py
+++ b/src/memory_store.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 import uuid
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ _EMBEDDING_MODEL = "all-MiniLM-L6-v2"
 # ---------------------------------------------------------------------------
 
 
-class MemoryCategory(str, Enum):
+class MemoryCategory(StrEnum):
     ERROR_PATTERN = "error_pattern"    # recurring error found in the project
     REVIEW_HISTORY = "review_history"  # past review of a file/function
 
@@ -382,7 +382,10 @@ class MemoryStore:
         return self._client
 
     async def _get_encoder(self) -> Any:
-        """Return or lazily create the SentenceTransformer encoder (async, CPU-bound load via thread)."""
+        """Return or lazily create the SentenceTransformer encoder.
+
+        Async, CPU-bound load via thread.
+        """
         if self._encoder is not None:
             return self._encoder
         SentenceTransformer = _try_import_sentence_transformers()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -12,10 +12,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
-from typing import Callable
+
+from .config import ModelConfig, Provider, RoleModelConfig
+from .context_builder import MRContext
+from .llm_client import LLMClient
 
 # Single-pass slot replacement — prevents injected content from expanding other slots
 _SLOTS_RE = re.compile(
@@ -23,14 +27,10 @@ _SLOTS_RE = re.compile(
     r'ARCH_DECISIONS|SECURITY_BASELINE|PREVIOUS_REVIEWS|FOCUS_AREAS)\]'
 )
 
-from .config import ModelConfig, Provider, RoleModelConfig
-from .context_builder import MRContext
-from .llm_client import LLMClient
-
 logger = logging.getLogger(__name__)
 
 
-class ReviewRole(str, Enum):
+class ReviewRole(StrEnum):
     DEVELOPER = "developer"
     ARCHITECT = "architect"
     TESTER = "tester"

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -27,13 +27,20 @@ from urllib.parse import urlparse
 
 from . import metrics as _metrics
 from .config import AppConfig, ReviewTarget, get_config
-from .memory_store import MemoryCategory, MemoryRecord, MemoryStore
-from .context_builder import MRContext, get_agents_md, get_docs_context, get_dynamic_context, get_security_baseline, get_task_context
+from .context_builder import (
+    MRContext,
+    get_agents_md,
+    get_docs_context,
+    get_dynamic_context,
+    get_security_baseline,
+    get_task_context,
+)
 from .db import Database, ReviewRecord
 from .gitlab_client import FileDiff, GitLabClient, MRInfo
 from .llm_client import LLMClient
+from .memory_store import MemoryCategory, MemoryRecord, MemoryStore
 from .notifier import notify as _dispatch_notify
-from .pipeline import PipelineManager, RoleResult, ReviewRole
+from .pipeline import PipelineManager, ReviewRole, RoleResult
 from .prompt_engine import PromptEngine
 from .queue_manager import ReviewJob
 
@@ -49,7 +56,7 @@ def _safe_mr_url(url: str) -> str:
     return url
 
 
-def _safe_mr_title(title: str) -> str:
+def _safe_mr_title(title: str | None) -> str:
     """Escape markdown chars that could break the link text."""
     title = title or ""
     return title.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
@@ -360,7 +367,7 @@ class Reviewer:
             # Only maintainers can push there, so AGENTS.md/docs/ are not attacker-controlled.
             # source_branch is used only for dynamic context (full file content of changed files).
             trusted_ref = mr.target_branch   # main/master — only maintainers push here
-            source_ref = mr.source_branch    # PR author's branch — untrusted for static context
+            _source_ref = mr.source_branch    # PR author's branch — untrusted for static context
 
             p = PromptEngine(prompts_dir=Path(review_cfg.prompts_dir))
 
@@ -450,7 +457,8 @@ class Reviewer:
             )
             parallel_results = [r for r in results if r.role != ReviewRole.REVIEWER]
 
-            risk_score = _compute_risk_score(mr, diffs, reviewer_result.findings if reviewer_result else "")
+            reviewer_findings = reviewer_result.findings if reviewer_result else ""
+            risk_score = _compute_risk_score(mr, diffs, reviewer_findings)
             record.risk_score = risk_score
             record.review_text = reviewer_result.findings if reviewer_result else ""
 
@@ -477,7 +485,11 @@ class Reviewer:
                                 category=MemoryCategory.ERROR_PATTERN,
                                 content=result.findings,
                                 metadata={
-                                    "role": result.role.value if hasattr(result.role, "value") else str(result.role),
+                                    "role": (
+                                        result.role.value
+                                        if hasattr(result.role, "value")
+                                        else str(result.role)
+                                    ),
                                     "mr_iid": job.mr_iid,
                                     "severity": "blocking",
                                 },
@@ -1227,9 +1239,9 @@ def _format_summary_comment(summary_text: str, inline_count: int) -> str:
 
 
 def _build_v2_comment(
-    mr: "MRInfo",
-    parallel_results: "list[RoleResult]",
-    reviewer_result: "RoleResult | None",
+    mr: MRInfo,
+    parallel_results: list[RoleResult],
+    reviewer_result: RoleResult | None,
     risk_score: int,
 ) -> str:
     """Build the composite GitLab comment for v2 pipeline results."""
@@ -1250,7 +1262,7 @@ def _build_v2_comment(
     }
 
     sections: list[str] = [
-        f"## 🤖 Automated Code Review (v2 Pipeline)\n",
+        "## 🤖 Automated Code Review (v2 Pipeline)\n",
         f"**Risk Score:** {risk_label} ({risk_score}/100)\n",
     ]
 
@@ -1272,7 +1284,8 @@ def _build_v2_comment(
         blocking_note = f" ⚠️ {result.blocking_count} blocking" if result.blocking_count else ""
         sections.append(
             f"<details>\n"
-            f"<summary>{emoji} <b>{result.role.value.title()} Review</b>{blocking_note}</summary>\n\n"
+            f"<summary>{emoji} <b>{result.role.value.title()} Review</b>"
+            f"{blocking_note}</summary>\n\n"
             f"{result.findings}\n\n"
             f"</details>\n"
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,7 @@ def test_per_role_models_yaml_parsing():
 def test_provider_url_scheme_validator_rejects_invalid():
     """Fix 5: Provider must reject non-http/https URLs."""
     from pydantic import ValidationError
+
     from src.config import Provider
 
     with pytest.raises(ValidationError, match="http or https"):
@@ -69,6 +70,7 @@ def test_provider_url_scheme_validator_accepts_https():
 def test_provider_api_key_is_secret_str():
     """Fix 6: api_key is SecretStr — not revealed in repr/str."""
     from pydantic import SecretStr
+
     from src.config import Provider
 
     p = Provider(id="x", name="X", url="http://localhost:11434", api_key="super-secret")

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import respx
@@ -23,7 +23,7 @@ BASE = "http://gitlab.test"
 
 @pytest.fixture
 def client():
-    c = GitLabClient(base_url=BASE, token="test-token", timeout=5)
+    c = GitLabClient(base_url=BASE, token="test-token", timeout=5)  # noqa: S106
     yield c
 
 
@@ -313,7 +313,6 @@ class TestGetSecurityBaseline:
     @pytest.mark.asyncio
     async def test_get_security_baseline_filters_by_keywords(self) -> None:
         """Only files containing security keywords are included."""
-        from src.context_builder import get_security_baseline
 
         tree = [
             {"path": "docs/threat-model.md", "type": "blob"},
@@ -341,7 +340,6 @@ class TestGetSecurityBaseline:
     @pytest.mark.asyncio
     async def test_get_security_baseline_empty_when_no_docs(self) -> None:
         """Returns empty string when docs/ doesn't exist."""
-        from src.context_builder import get_security_baseline
 
         client = MagicMock()
         client.list_tree = AsyncMock(return_value=[])

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -10,9 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.memory_store import MemoryCategory, MemoryRecord, MemoryStore
 from src.config import MemoryConfig
-
+from src.memory_store import MemoryCategory, MemoryRecord, MemoryStore
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from src.context_builder import MRContext
-from src.pipeline import PipelineManager, ReviewRole, RoleResult
-
+from src.pipeline import PipelineManager, ReviewRole
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -265,7 +264,7 @@ class TestPipelineRun:
             # Final reviewer response includes APPROVE
             if "Final Review" in system_prompt or "PREVIOUS_REVIEWS" in system_prompt:
                 return "## Review\n\nAll good.\n\n---\n## Decision: APPROVE\n\n**Reason:** OK"
-            return f"## Review\n\nLooks good.\n[HIGH] Minor issue found."
+            return "## Review\n\nLooks good.\n[HIGH] Minor issue found."
 
         llm = MagicMock()
         llm.chat = AsyncMock(side_effect=mock_chat)
@@ -387,28 +386,36 @@ class TestPipelineV2Config:
         """pipeline_v2=False must be readable from config."""
         from src.config import AppConfig
 
+        _p1 = {"id": "p1", "name": "test-provider", "type": "llamacpp",
+               "url": "http://localhost:8080", "active": True}
         cfg_data = {
             "gitlab": {"url": "http://gl.example.com", "auth_type": "token"},
-            "providers": [{"id": "p1", "name": "test-provider", "type": "llamacpp", "url": "http://localhost:8080", "active": True}],
+            "providers": [_p1],
             "model": {"provider_id": "p1", "name": "test-model"},
             "review": {"pipeline_v2": False},
         }
         cfg = AppConfig.model_validate(cfg_data)
         assert cfg.review.pipeline_v2 is False
 
-    def test_pipeline_v2_true_enables_new_pipeline(self) -> None:
+    def test_pipeline_v2_true_enables_new_pipeline(self, tmp_path) -> None:
         """pipeline_v2=True must be readable from config."""
+        import os
+
         from src.config import AppConfig
 
+        prompts_dir = str(tmp_path / "prompts")
+        os.makedirs(prompts_dir, exist_ok=True)
+        _p1 = {"id": "p1", "name": "test-provider", "type": "llamacpp",
+               "url": "http://localhost:8080", "active": True}
         cfg_data = {
             "gitlab": {"url": "http://gl.example.com", "auth_type": "token"},
-            "providers": [{"id": "p1", "name": "test-provider", "type": "llamacpp", "url": "http://localhost:8080", "active": True}],
+            "providers": [_p1],
             "model": {"provider_id": "p1", "name": "test-model"},
-            "review": {"pipeline_v2": True, "prompts_dir": "/tmp/prompts"},
+            "review": {"pipeline_v2": True, "prompts_dir": prompts_dir},
         }
         cfg = AppConfig.model_validate(cfg_data)
         assert cfg.review.pipeline_v2 is True
-        assert cfg.review.prompts_dir == "/tmp/prompts"
+        assert cfg.review.prompts_dir == prompts_dir
 
 
 # ---------------------------------------------------------------------------
@@ -460,7 +467,7 @@ class TestPipelineRunFinalReceivesAllRoles:
             arch_decisions="",
         )
 
-        results = await pm.run(ctx)
+        await pm.run(ctx)
 
         # Final call must contain results from all 4 parallel roles
         final_prompt = next((a for a in call_args if "Final:" in a), None)
@@ -651,8 +658,14 @@ class TestPerRoleModelConfig:
                 "pipeline_v2": True,
                 "per_role_models": {
                     "roles": {
-                        "architect": {"provider_id": "openrouter", "name": "anthropic/claude-sonnet-4-5"},
-                        "security": {"provider_id": "openrouter", "name": "anthropic/claude-sonnet-4-5"},
+                        "architect": {
+                            "provider_id": "openrouter",
+                            "name": "anthropic/claude-sonnet-4-5",
+                        },
+                        "security": {
+                            "provider_id": "openrouter",
+                            "name": "anthropic/claude-sonnet-4-5",
+                        },
                         "developer": {"provider_id": "openrouter", "name": "qwen2.5-coder-7b"},
                     }
                 },
@@ -707,7 +720,7 @@ class TestPerRoleModelConfig:
             diff="diff",
             arch_decisions="",
         )
-        results = await pm.run(ctx)
+        await pm.run(ctx)
 
         # architect_llm must have been called
         assert arch_llm.chat.call_count == 1
@@ -715,10 +728,10 @@ class TestPerRoleModelConfig:
         assert global_llm.chat.call_count == 4
 
     @pytest.mark.asyncio
-    async def test_backward_compat_run_uses_global_llm_for_all_roles(self, prompts_dir: Path, mock_llm: MagicMock):
+    async def test_backward_compat_run_uses_global_llm_for_all_roles(
+        self, prompts_dir: Path, mock_llm: MagicMock
+    ):
         """AC4: Without per_role_models, all roles in run() use the same global LLMClient."""
-        from src.config import RoleModelConfig
-        from unittest.mock import AsyncMock
 
         call_clients = []
 

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -802,7 +802,14 @@ class TestBuildDiffContentMap:
 
 def _make_v2_cfg(memory_enabled: bool = False):
     """Build a minimal AppConfig for v2 pipeline tests."""
-    from src.config import AppConfig, GitLabConfig, MemoryConfig, ModelConfig, Provider, ReviewConfig
+    from src.config import (
+        AppConfig,
+        GitLabConfig,
+        MemoryConfig,
+        ModelConfig,
+        Provider,
+        ReviewConfig,
+    )
 
     return AppConfig(
         providers=[Provider(id="p", name="P", type="ollama", url="http://x", active=True)],
@@ -891,7 +898,7 @@ class TestMemoryV2:
         self, reviewer, db, mock_mr, mock_diffs
     ):
         """recall() called before pipeline, remember() called after with blocking findings."""
-        from unittest.mock import AsyncMock, MagicMock, call, patch
+        from unittest.mock import AsyncMock, MagicMock, patch
 
         from src.pipeline import ReviewRole, RoleResult
         from src.reviewer import set_database, set_memory_store
@@ -1026,6 +1033,7 @@ class TestSummaryCommentMrUrl:
         comment = mock_gitlab.post_mr_note.call_args[0][2]
         assert "[MR #7" in comment, f"Expected MR link in comment, got:\n{comment[:300]}"
         assert "http://gitlab.example.com/mr/7" in comment
+        assert comment.startswith("🔍 [MR"), f"Expected link at start, got:\n{comment[:200]}"
 
     async def test_summary_no_mr_link_when_url_empty(
         self, reviewer, mock_gitlab, mock_llm, db, cfg_with_target, mock_mr
@@ -1042,7 +1050,9 @@ class TestSummaryCommentMrUrl:
 
         mock_gitlab.post_mr_note.assert_called_once()
         comment = mock_gitlab.post_mr_note.call_args[0][2]
-        assert "[MR #7" not in comment, f"Did not expect MR link when url is empty:\n{comment[:300]}"
+        assert "[MR #7" not in comment, (
+            f"Did not expect MR link when url is empty:\n{comment[:300]}"
+        )
 
     async def test_summary_no_mr_link_when_url_has_javascript_scheme(
         self, reviewer, mock_gitlab, mock_llm, db, cfg_with_target, mock_mr


### PR DESCRIPTION
## Summary

Cleans up all 52 pre-existing ruff lint errors and adds minor test improvements.

### Changes

**Auto-fixed by ruff:**
- `I001`: import block sorting (8 files)
- `UP037`: remove quoted type annotations
- `F401`: remove unused imports
- `F811`: remove redefined names
- `F541`: remove f-strings without placeholders

**Manual fixes:**
- `E501` (line too long): extracted intermediate variables (`api_key`, `is_active`, `name_lower`, `reviewer_findings`)
- `E402` (import order): moved `_SLOTS_RE` regex after all imports in `pipeline.py`
- `F841` (unused variable): `source_ref → _source_ref`, removed unused `results =` in tests
- `UP042`: `class X(str, Enum)` → `StrEnum` for `ReviewRole` and `MemoryCategory` (Python 3.11+)
- `S108` (/tmp usage): replaced hardcoded `/tmp/prompts` with `tmp_path` pytest fixture

**Issue #8:** added `assert comment.startswith("🔍 [MR")` to verify MR link is prepended  
**Issue #10:** `_safe_mr_title(title: str)` → `str | None` to reflect actual usage

### Review
- Round 1: 0 blocking — Security CLEAR ✅ · Architect APPROVE ✅ · QA PASS ✅ · Python Dev APPROVE ✅

### Tests
```
589 passed
ruff: All checks passed!
```

Closes #11, closes #8, closes #10