### PR TITLE
chore: Content-Length pre-check in rules API + 6 tests (#14)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,7 @@ After v0.2: open `http://server:8000/ui/` to configure everything.
 - **Route ordering in FastAPI**: literal paths (`/stats/weekly`, `/export.csv`) MUST be registered BEFORE parameterized (`/{review_id}`) — otherwise FastAPI captures them as path params
 - **Automation Rules (FT-6)**: `if_files_match` and `if_lines_changed_gt` require diff data not present in webhook payload → conditions with empty `changed_files`/`lines_changed=0` evaluate to False (not True). This is intentional — only `if_author_in` and `if_target_branch` work fully at enqueue time without extra API calls. When skipped, a `DEBUG`-level log is emitted (search for "skipped — changed_files not available").
 - **ActionType warning log**: `webhook.py` iterates `engine.evaluate(ctx)` actions and logs `WARNING` for any action type other than `SKIP_REVIEW` (e.g. `add_label`, `assign_reviewer`, `force_full_review`, `notify_webhook`). This is deliberate dead-code guard — implement the action handler, then remove the warning for that type.
+- **Content-Length pre-check pattern**: In `rules_api.py` (and `webhook.py`), always check `request.headers.get("content-length")` BEFORE `await request.body()`. This avoids reading oversized bodies into memory. Keep the post-read `len(body_bytes) > MAX` check as a fallback for chunked Transfer-Encoding (no Content-Length header). Pattern: pre-check raises HTTP 413; post-read check also raises 413.
 - **rules.yml location**: always sibling of `config.yml`; path set via `set_rules_path()` in `main.py`. Rules engine re-reads the file on every webhook call (no caching) — hot-reload friendly
 - **rules_api.py**: `_rules_path()` reads the module-level variable from `webhook.py` at call time — do not cache it at import time
 - **Inline comment placement**: GitLab Discussions API requires `old_line` for context lines (unchanged lines in the diff) — passing only `new_line` causes comment to be silently misplaced. Use `_parse_diff_line_map()` to determine whether to include `old_line`
@@ -322,3 +323,4 @@ After v0.2: open `http://server:8000/ui/` to configure everything.
 | URL validator for provider.url (http/https only) | v0.15 | ✅ Done |
 | timeout: int = 300 in ModelConfig (configurable) | v0.15 | ✅ Done |
 | chore: ruff lint fix — 52 errors fixed (#11, #8, #10) | chore | ✅ Done |
+| Content-Length pre-check in rules_api.py + body limit tests (#14) | chore | ✅ Done |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,7 @@
+# BACKLOG
+
+## Issues
+
+| # | Title | Status |
+|---|-------|--------|
+| 14 | Content-Length pre-check in rules_api.py + body limit tests | ✅ Done |

--- a/src/api/rules_api.py
+++ b/src/api/rules_api.py
@@ -80,6 +80,12 @@ async def save_rules(request: Request) -> JSONResponse:
     """Accept YAML body, validate, and save as rules.yml."""
     p = _require_path()
 
+    content_length = request.headers.get("content-length")
+    if content_length and int(content_length) > MAX_RULES_BODY:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Request body too large (max {MAX_RULES_BODY // 1024} KB)",
+        )
     body_bytes = await request.body()
     if len(body_bytes) > MAX_RULES_BODY:
         raise HTTPException(
@@ -131,9 +137,18 @@ async def validate_rules(yaml_param: str = Query(default="", alias="yaml")) -> J
 @router.post("/validate")
 async def validate_rules_post(request: Request) -> JSONResponse:
     """Validate YAML rules body (POST version for large configs)."""
+    content_length = request.headers.get("content-length")
+    if content_length and int(content_length) > MAX_RULES_BODY:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Request body too large (max {MAX_RULES_BODY // 1024} KB)",
+        )
     body_bytes = await request.body()
     if len(body_bytes) > MAX_RULES_BODY:
-        return JSONResponse({"valid": False, "error": "Request body too large", "count": 0})
+        raise HTTPException(
+            status_code=413,
+            detail=f"Request body too large (max {MAX_RULES_BODY // 1024} KB)",
+        )
     yaml_text = body_bytes.decode("utf-8")
     if not yaml_text.strip():
         return JSONResponse({"valid": True, "error": None, "count": 0})

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -415,3 +415,193 @@ class TestWebhookWithRules:
             data = resp.json()
             assert data["status"] == "accepted"
             mock_queue.enqueue.assert_awaited_once()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# TestRulesApiBodyLimit
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestRulesApiBodyLimit:
+    """Tests for body size limits and validate endpoints."""
+
+    def _make_app(self, rules_path: str):
+        """Build a minimal FastAPI app with rules_router wired."""
+        from fastapi import FastAPI
+
+        from src.api.rules_api import router as rules_router
+
+        app = FastAPI()
+        app.include_router(rules_router)
+        return app
+
+    def test_load_rules_exceeds_512kb_raises(self, tmp_path):
+        """load_rules raises ValueError for files > 512 KB."""
+        rules_file = tmp_path / "rules.yml"
+        rules_file.write_text("x: " + "a" * (512 * 1024 + 1), encoding="utf-8")
+        with pytest.raises(ValueError, match="maximum size"):
+            load_rules(str(rules_file))
+
+    @pytest.mark.asyncio
+    async def test_save_rules_body_too_large_returns_413(self, tmp_path):
+        """POST /api/v1/rules with body > 512 KB returns 413."""
+        from httpx import ASGITransport, AsyncClient
+
+        rules_yml = tmp_path / "rules.yml"
+
+        with patch("src.webhook._rules_path", str(rules_yml)):
+            app = self._make_app(str(rules_yml))
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                big_body = b"x: " + b"a" * (512 * 1024 + 1)
+                resp = await client.post(
+                    "/api/v1/rules",
+                    content=big_body,
+                    headers={"content-type": "text/plain"},
+                )
+        assert resp.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_validate_rules_post_valid(self, tmp_path):
+        """POST /api/v1/rules/validate with valid YAML returns {valid: true}."""
+        from httpx import ASGITransport, AsyncClient
+
+        rules_yml = tmp_path / "rules.yml"
+
+        with patch("src.webhook._rules_path", str(rules_yml)):
+            app = self._make_app(str(rules_yml))
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                valid_yaml = textwrap.dedent("""
+                    rules:
+                      - name: Skip bots
+                        condition:
+                          if_author_in:
+                            - dependabot
+                        actions:
+                          - type: skip_review
+                        stop: true
+                """)
+                resp = await client.post(
+                    "/api/v1/rules/validate",
+                    content=valid_yaml.encode(),
+                    headers={"content-type": "text/plain"},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is True
+        assert data["error"] is None
+        assert data["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_validate_rules_post_invalid(self, tmp_path):
+        """POST /api/v1/rules/validate with invalid YAML returns {valid: false}."""
+        from httpx import ASGITransport, AsyncClient
+
+        rules_yml = tmp_path / "rules.yml"
+
+        with patch("src.webhook._rules_path", str(rules_yml)):
+            app = self._make_app(str(rules_yml))
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/api/v1/rules/validate",
+                    content=b"rules: [not: valid: yaml: (",
+                    headers={"content-type": "text/plain"},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is False
+        assert data["error"] is not None
+
+    @pytest.mark.asyncio
+    async def test_validate_rules_get_valid(self, tmp_path):
+        """GET /api/v1/rules/validate?yaml=... with valid YAML returns {valid: true}."""
+        from urllib.parse import quote
+
+        from httpx import ASGITransport, AsyncClient
+
+        rules_yml = tmp_path / "rules.yml"
+
+        with patch("src.webhook._rules_path", str(rules_yml)):
+            app = self._make_app(str(rules_yml))
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                valid_yaml = textwrap.dedent("""
+                    rules:
+                      - name: Skip bots
+                        condition:
+                          if_author_in:
+                            - dependabot
+                        actions:
+                          - type: skip_review
+                """)
+                resp = await client.get(
+                    f"/api/v1/rules/validate?yaml={quote(valid_yaml)}",
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_webhook_unimplemented_action_logs_warning(self, tmp_path, caplog):
+        """Non-skip_review actions log a warning but do not block enqueue."""
+        import logging
+
+        from fastapi import FastAPI
+        from httpx import ASGITransport, AsyncClient
+
+        rules_yml = tmp_path / "rules.yml"
+        rules_yml.write_text(
+            textwrap.dedent("""
+                rules:
+                  - name: Add label
+                    condition:
+                      if_author_in:
+                        - alice
+                    actions:
+                      - type: add_label
+                        value: needs-review
+            """),
+            encoding="utf-8",
+        )
+
+        mock_cfg = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+        mock_cfg.gitlab.webhook_secret = ""
+
+        with (
+            patch("src.webhook._rules_path", str(rules_yml)),
+            patch("src.webhook._queue") as mock_queue,
+            patch("src.webhook.get_config", return_value=mock_cfg),
+            caplog.at_level(logging.WARNING, logger="src.webhook"),
+        ):
+            mock_queue.enqueue = AsyncMock(return_value=True)
+
+            from src.webhook import make_webhook_router
+
+            app = FastAPI()
+            app.include_router(make_webhook_router())
+
+            payload = {
+                "object_attributes": {"action": "open", "iid": 7, "target_branch": "main"},
+                "project": {"id": 42},
+                "user": {"username": "alice"},
+            }
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                resp = await client.post(
+                    "/webhook/gitlab",
+                    json=payload,
+                    headers={"X-Gitlab-Event": "Merge Request Hook"},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
+        assert any("not yet implemented" in r.message for r in caplog.records)
+        mock_queue.enqueue.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes #14. Adds missing tests and improves request body size limiting in rules API.

### Changes

**`src/api/rules_api.py`:**
- Added `Content-Length` header pre-check before `await request.body()` in `save_rules()` and `validate_rules_post()` — consistent with pattern in `webhook.py`
- Post-read check retained as fallback for chunked transfer encoding

**`tests/test_rules.py` — 6 new tests in `TestRulesApiBodyLimit`:**
- `test_load_rules_exceeds_512kb_raises` — load_rules() rejects files > 512 KB
- `test_save_rules_body_too_large_returns_413` — POST /api/v1/rules returns 413 on oversized body
- `test_validate_rules_post_valid` / `test_validate_rules_post_invalid` — POST /validate happy/sad path
- `test_validate_rules_get_valid` — GET /validate?yaml=... coverage
- `test_webhook_unimplemented_action_logs_warning` — non-skip action logs warning, enqueue proceeds

### Review
- Round 1: 0 blocking — Python Dev APPROVE ✅ · QA PASS ✅ · Security CLEAR ✅

### Tests
```
623 passed (6 new)
ruff: All checks passed!
```